### PR TITLE
Policy updates regarding Posting Representations of Images in Rubin Communication Channels

### DIFF
--- a/DMTN-286.tex
+++ b/DMTN-286.tex
@@ -16,7 +16,8 @@
 
 \author{%
 William O'Mullane,
-Frossie Economou
+Frossie Economou, 
+Phil Marshall
 }
 
 \setDocRef{DMTN-286}
@@ -28,7 +29,7 @@ Frossie Economou
 % \setDocCurator{The Curator of this Document}
 
 \setDocAbstract{%
-We have a lot of fairly open communication channels which should not receive image data during embargo periods. This is more of a dilemma  in commissioning with the longer embargo period but persists throughout operations. This note discusses the issue and draws some conclusions.
+We have a lot of fairly open communication channels which should not receive image data during embargo periods. This is more of a dilemma  in commissioning with the longer embargo period but persists throughout operations. This technote discusses the issue and draws some conclusions, and hence serves as a policy document.
 }
 
 % Change history defined here.
@@ -36,7 +37,8 @@ We have a lot of fairly open communication channels which should not receive ima
 % Fields: VERSION, DATE, DESCRIPTION, OWNER NAME.
 % See LPM-51 for version number policy.
 \setDocChangeRecord{%
-  \addtohist{1.0}{2024-04-30}{Relase after \jira{RFC-1007}}{William O'Mullane, Keith Bechtol}
+  \addtohist{1.1}{2024-04-30}{Revised guidance on posting image representations}{Phil Marshall}
+  \addtohist{1.0}{2024-04-30}{Release after \jira{RFC-1007}}{William O'Mullane, Keith Bechtol}
   \addtohist{0.2}{2024-04-09}{Unreleased.}{William O'Mullane, Keith Bechtol}
   \addtohist{0.1}{2024-03-06}{Unreleased.}{William O'Mullane}
 }

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ DMTN-286
 
 We have a lot of fairly open communication channels which should not receive image data during embargo periods. 
 This is more of a dilemma  in commissioning with the longer embargo period but persists throughout operations. 
-This note discusses the issue and draws some conclusions.
+This technote discusses the issue and draws some conclusions, and hence serves as the policy document in support of the Staff Access Form at https://ls.st/staff-access-form.
 
 Links
 =====

--- a/body.tex
+++ b/body.tex
@@ -4,10 +4,11 @@ The briefest summary of this topic is that images during the embargo period and 
 That space needs to be set up and even there some care should be taken.
 
 As outlined in \citeds{DMTN-199} only the Rubin team have access to pixel data for an embargo period of 80 hours in operations and 30 days during commissioning. We assume this also means PNG or other format images captured from screens, etc., which may show pixel data, e.g., from RubinTV on the summit.
-Catalog data is not embargoed though falls under data rights restrictions \citeds{RDO-013}.
+In this document we use the term ``image representation'' to describe these kinds of images, to distinguish them from image data (in FITS files or provided by the butler).
+Catalog data is not embargoed but falls under data rights restrictions \citeds{RDO-013}.
 
 Secure or authenticated links to pixel images are mentioned in several instances below.
-These could be any pointer to an image which one can only access by login - hence verifying one has access to the image. Examples could be a butler dataId, a jupyter notebook to be run at USDF, an unsigned S3 URL\footnote{starting with s3:// but not usable in a browser}.
+These could be any pointer to an image or image representation which one can only access by login - hence verifying one has access to the image. Examples could be a butler dataId, a jupyter notebook to be run at USDF, an unsigned S3 URL\footnote{starting with s3:// but not usable in a browser}.
 
 
 \section{General policy} \label{sec:genpol}
@@ -16,12 +17,15 @@ This document describes policy implementation for a concrete set of tools.
 In general we may state:
 
 \begin{itemize}
-\item No pixel images seen by the team in any communication space should be shared outside the space at anytime.
-\item Images should not be left open on laptops at meetings or public spaces.
-\item Images should not be shown in presentations.
+\item Proprietary data products from commissioning, including all focal plane scientific data, may NOT be shared beyond the Rubin team until their release as part of the Early Science Program. This includes all embargoed images and data products.
+\item Pixel data is not to be retained more than incidentally/temporarily on non-embargo storage, including personal/work laptops/desktops and USDF home/shared/scratch directories.
+\item Image representations should not be left open on laptops at meetings or public spaces.
+\item Image representations should not be shown in presentations outside of Rubin meetings or communication channels (such as Rubin Slack, see below).
+\item No image representations seen by the team in any communication space should be shared outside of the Rubin communication channels at anytime.
 \end{itemize}
 
-This is even more important before System First Light where we need to carefully control the public first light images.
+
+This is even more important before System First Light where we need to carefully control the public first light images and their representations.
 
 In general, we are trying to maintain a broadly open system for Rubin.
 This implies that team members and collaborators have access to a wealth of other information about Rubin, aside from pixel data.
@@ -58,12 +62,12 @@ Getting auth protection for some notes for some time is not very consistent and 
 
 \subsubsection{Proposed policy for technotes}
 Continue current default of public technotes with development occurring on branches. The review process described in \citeds{SITCOMTN-076} occurs at the stage that a development branch is being merged to the main branch via a Pull Request. The content of a technote is considered to be approved for release, once merged to the main branch.
-During development, embargoed pixel images can only be referenced in technotes as authenticated links --- pixel images (e.g., PNGs) must NOT appear in technotes until specifically approved for release.
+During development, embargoed pixel images can only be referenced in technotes as authenticated links --- pixel image representations (e.g., PNGs) must NOT appear in technotes until specifically approved for release.
 
 \subsection{GitHub}
 There may be many things in repos in GitHub, e.g., draft technotes, Construction paper drafts, notebooks with plots.
 These could be in private repos.
-Even so, private repos are visible to all team members on github so care needs to be taken.
+Even so, private repos are visible to all team members on GitHub so care needs to be taken.
 
 An alternative would be to again use authenticated links to images until they are not embargoed and keep all notes public.
 
@@ -81,7 +85,7 @@ SITCOM would like a Confluence space where they could share presentations with p
 This could be allowed by making all such meeting pages private and ensuring the SITCOM group is appropriately restricted.
 
 \subsubsection{Proposed policy for Confluence}
-Do not up load any pixel images or parts of pixel images or screenshots of images to confluence.
+Do not up load any pixel images or any representations of pixel images or screenshots of images to confluence.
 Use an authenticated link to any image rather than the actual image if it is needed in a page.
 
 \subsection{Jira}
@@ -90,8 +94,8 @@ Other projects are password protected but anyone with access to Jira may view su
 Its not obvious we could even secure such a system.
 
 \subsubsection{Proposed policy for Jira}
-Do not up load any pixel images or parts of pixel images to Jira.
-Use an authenticated link to any image rather than the actual image if it is needed in a ticket.
+Do not up load any pixel images or representations of pixel images to Jira.
+Use an authenticated link to any image rather than a representation of an image if it is needed in a ticket.
 It is acceptable to put a screenshot of an effect on a CCD if it is pertinent to the issue.
 Some details of this type of image data are given in Section 3.4 of \citeds{SITCOMTN-076}.
 
@@ -113,22 +117,23 @@ Allowed groups are those involved in commissioning plus DM and SP staff involved
 Email is inherently insecure (few of us use encryption) and list servers are fairly open.
 
 \subsubsection{Proposed policy for Email}
-Do not attach Rubin pixel images or parts of image to emails.
+Do not attach Rubin pixel images or representations of image to emails.
 Use authenticated links to images where needed.
 
-\subsection{ Community.lsst.org}
+\subsection{Community.lsst.org}
 Community is public and completely open.
 \subsubsection{Proposed policy for community}
-Only images already made public via communications should be posted in community.
+Only images or representations already made public via communications should be posted in community.
 Statistical plots to explain issues are ok.
 
-\subsection{ Google and other open editing platforms}
-There are many other ways to share images not mentioned in this document.
+\subsection{Google and other open editing platforms}
+There are many other ways to share representations of images that are not mentioned in this document.
 Images should not be shared {\emph publicly} on any of these including Google, Microsoft360, Dropbox.
 Many of these systems are used in a completely open way with ``anyone with link can access'': this is not allowable.
 
-\subsubsection{Proposed policy for Google and other sites}
-Only images already made public via communications should be posted in publicly accessible locations.
+\subsubsection{Policy for Google and other sites}
+Only representations of images already made public via communications should be posted in publicly accessible locations.
 Statistical plots to explain issues are ok.
-In a limited way it would be acceptable to post images in locked down folders or documents with restricted access to a known group of authenticated individuals.
+In a limited way it is acceptable to post representations of images in locked down folders or documents with restricted access to a known group of authenticated individuals.
+For example, representations of images may be included in a restricted, not world-viewable, Google slide deck, the URL of which may be posted in a Rubin Observatory Slack channel.
 

--- a/body.tex
+++ b/body.tex
@@ -136,4 +136,8 @@ Only representations of images already made public via communications should be 
 Statistical plots to explain issues are ok.
 In a limited way it is acceptable to post representations of images in locked down folders or documents with restricted access to a known group of authenticated individuals.
 For example, representations of images may be included in a restricted, not world-viewable, Google slide deck, the URL of which may be posted in a Rubin Observatory Slack channel.
+As with the policy for posting image representations to Slack directly: 
+sky position and observation timestamp metadata must not be included; 
+smaller full resolution images showing particular features are fine, as are re-binned larger-field images; 
+metadata values of `day_obs`, `seq_num` and `detector` may be overlaid or otherwise provided.
 

--- a/body.tex
+++ b/body.tex
@@ -25,7 +25,7 @@ This is even more important before System First Light where we need to carefully
 
 In general, we are trying to maintain a broadly open system for Rubin.
 This implies that team members and collaborators have access to a wealth of other information about Rubin, aside from pixel data.
-During commission, much of this information will be about problems.
+During commissioning, much of this information will be about problems.
 We do not wish to hide the issues and problems, and we expect the community to be respectful of this information and consider the state of the system, which in commissioning is not finished.
 
 \section {Systems that need policies}
@@ -34,7 +34,7 @@ In various discussions the list of tools we need to have polices for are:
 \begin{enumerate}
     \item Confluence
     \item Jira
-    \item github (e.g., draft technotes, Construction paper drafts, notebooks with plots)
+    \item GitHub (e.g., draft technotes, Construction paper drafts, notebooks with plots)
     \item technotes on lsst.io
     \item Slack
     \item summit tooling (i.e RubinTV)
@@ -45,7 +45,7 @@ In various discussions the list of tools we need to have polices for are:
 \end{enumerate}
 
 We discuss each in a section below.
-Tech notes and Slack are possibly most heavily used so lets start there.
+Tech notes and Slack are possibly most heavily used so let's start there.
 
 \input{slack}
 
@@ -58,16 +58,16 @@ Getting auth protection for some notes for some time is not very consistent and 
 
 \subsubsection{Proposed policy for technotes}
 Continue current default of public technotes with development occurring on branches. The review process described in \citeds{SITCOMTN-076} occurs at the stage that a development branch is being merged to the main branch via a Pull Request. The content of a technote is considered to be approved for release, once merged to the main branch.
-During development, embargoed pixel images can only be referenced in technotes as authenticated links --- pixel images (e.g., PNGs) must NOT appear in technotes until specifically approved for release
+During development, embargoed pixel images can only be referenced in technotes as authenticated links --- pixel images (e.g., PNGs) must NOT appear in technotes until specifically approved for release.
 
-\subsection{Github}
-There may be many things in repos in github, e.g., draft technotes, Construction paper drafts, notebooks with plots.
+\subsection{GitHub}
+There may be many things in repos in GitHub, e.g., draft technotes, Construction paper drafts, notebooks with plots.
 These could be in private repos.
 Even so, private repos are visible to all team members on github so care needs to be taken.
 
 An alternative would be to again use authenticated links to images until they are not embargoed and keep all notes public.
 
-\subsubsection{Proposed policy for Github}
+\subsubsection{Proposed policy for GitHub}
 Rendered notebooks containing image data must not appear in public repos.
 Notebooks should be linked via Timesquare with authenticated access.
 
@@ -95,7 +95,7 @@ Use an authenticated link to any image rather than the actual image if it is nee
 It is acceptable to put a screenshot of an effect on a CCD if it is pertinent to the issue.
 Some details of this type of image data are given in Section 3.4 of \citeds{SITCOMTN-076}.
 
-\subsection{summit tooling (i.e RubinTV)}
+\subsection{Summit Tooling (i.e. RubinTV)}
 This all has to be secured for commissioning use.
 We should aim to put this in place around ComCam on sky July 2024.
 
@@ -109,13 +109,12 @@ USDF tooling should only be accessible to USDF account holders who are in the co
 Ensure only account holders in allowed groups have access to USDF tooling.
 Allowed groups are those involved in commissioning plus DM and SP staff involved in QA and essential operations trouble shooting at USDF.
 
-\subsection{Emails and email  lists }
+\subsection{Emails and email lists}
 Email is inherently insecure (few of us use encryption) and list servers are fairly open.
 
 \subsubsection{Proposed policy for Email}
 Do not attach Rubin pixel images or parts of image to emails.
 Use authenticated links to images where needed.
-
 
 \subsection{ Community.lsst.org}
 Community is public and completely open.
@@ -126,7 +125,7 @@ Statistical plots to explain issues are ok.
 \subsection{ Google and other open editing platforms}
 There are many other ways to share images not mentioned in this document.
 Images should not be shared {\emph publicly} on any of these including Google, Microsoft360, Dropbox.
-Many of these systems are used in a completely open way with "anyone with link can access" this is not allowable.
+Many of these systems are used in a completely open way with ``anyone with link can access'': this is not allowable.
 
 \subsubsection{Proposed policy for Google and other sites}
 Only images already made public via communications should be posted in publicly accessible locations.

--- a/slack.tex
+++ b/slack.tex
@@ -49,6 +49,12 @@ Reuse of lsst.slack.com has had some advantages:
 \end{itemize}
 We can revisit this approach after commissioning.
 
-Even though this is a private space it is not encrypted and not all project members have access to commissioning data.
-Some care, such as not posting full images and certainly not frequently doing so, should be taken.
-The assumption is small screen grabs (PNG or JPG)  of features would be shared in this space which is fine.
+\subsubsection{Policy for Rubin Slack}
+
+Even though Rubin Observatory Slack is a private space it is not encrypted and not all observatory staff have access to commissioning data.
+
+Some care needs to be taken when posting PNG or screenshot image representations in a Rubin Observatory Slack channel. 
+Full resolution images greater than 25k pixels on a side must not be posted.
+Sky position and observation timestamp metadata must not be included. 
+Smaller full resolution images showing particular features are fine, as are re-binned larger-field images. 
+Metadata values of `day_obs`, `seq_num` and `detector` may be overlaid or otherwise provided with image representations.

--- a/slack.tex
+++ b/slack.tex
@@ -1,54 +1,53 @@
 \subsection{Slack} \label{sec:slack}
 
-We have a wide variety of very open channels on Slack, these include large numbers of science collaborators and member of the astronomy community.
-So far, AuxTel and Simonyi star tracker images have been shared frequently on certain Slack channels which are not private.
-There is the possibility to have private channels on Slack --- we have few and tend to avoid them for several reasons: they are not discoverable, some bots don't work in them, etc.
-Even using Private channels, we would face a problem of members potentially inviting non-staff to the channel where images may be shown.
+We have a wide variety of very open channels on LSSTC Slack, these include large numbers of science collaborators and members of the astronomy community.
+Prior to October 2024, AuxTel and Simonyi star tracker images were shared frequently on certain Slack channels which are not private.
+There is the possibility to have private channels on Slack --- we have a few in LSSTC Slack and tend to avoid them for several reasons: they are not discoverable, some bots don't work in them, etc.
+Even using Private channels, we face a problem in LSSTC Slack of members potentially inviting non-staff to the channel where images may be shown.
 
-
-The current (LSSTC) Slack workspace was intentionally conceived as a community (including LSST Science Collaborations) inclusive space. This is at odds with a number of goals:
+The LSSTC Slack workspace was intentionally conceived as a community (including LSST Science Collaborations) inclusive space. 
+Since September 2024 we have been operating a separate Rubin Observatory Slack workspace, whose access is restricted to ``Rubin team members.''  
+This has the following data security and privacy benefits.
 
 \begin{itemize}
-\item  All channels would be available to all staff in the space --- no problem sharing images as long as ALL agree they never leave the space.
-This allows us a great project space to enjoy successes as they arise.
-\item  Fail quietly: We need a space where we can openly discuss problems (e.g. “omg what if we crack the AuxTel array” discussion in an open channel)
+\item  All Rubin Slack channels are available to all staff in the space --- no problem sharing images as long as ALL agree they never leave the space.
+This allows us a great internal space to enjoy successes as they arise.
+\item  Fail quietly: We need a workspace where we can openly discuss problems (e.g. “omg what if we crack the AuxTel array” discussion in an open channel)
 \item Embargo: Freely post data without having to stop and think whether it is embargoed.
 \item GitOps: Slack is “the UNIX command line” for highly distributed teams. SQuaRE offers (and plans on expanding its offerings) of slackbots that actively manipulate project resources, report on project data, issue alerts on operational services etc. Being assured that only trusted staff have access allows us to expand what these services can do.
-\item High Priority:  This gives a high-importance lower volume workspace that we can less disruptively monitor out of hours, during holidays and vacations and overall busy times, reducing the communication attack surface.
+\item High Priority:  Rubin Slack gives a high-importance lower volume workspace that we can less disruptively monitor out of hours, during holidays and vacations and overall busy times, reducing the communication attack surface.
 \item Privacy: We already pin phone numbers to certain channels, and there are concerns about freely sharing staff phone numbers, vacation schedules etc
-\item On/Off-boarding: Even if someone is off-boarded from the project, there are legitimate reasons they should still maintain their wider community slack access. A staff-only slack can be tightly controlled together with other high value project access.
-\item Slack Culture: We have issues where slack cultures class, eg. community folks at-channel just because a seminar is about to start, respecting quiet days etc. A separate workspace can maintain a more ops-oriented slack culture. It is also easier to respond to inappropriate behavior when it’s your own staff engaging in it.
+\item On/Off-boarding: Even if someone is off-boarded from the project, there are legitimate reasons they should still maintain their wider community slack access. A staff-only slack can be tightly controlled together with other high value observatory access.
+\item Slack Culture: We have issues where slack cultures clash, eg. community folks at-channel just because a seminar is about to start, respecting quiet days etc. A separate workspace can maintain a more ops-oriented slack culture. It is also easier to respond to inappropriate behavior when it’s your own staff engaging in it.
 \end{itemize}
 
-There are some reasons we may not with to have a private Slack:
+There are some risks associated with a private Rubin-only Slack:
 
 \begin{itemize}
-\item ``We are at risk of abandoning the community'': The motivation behind LSSTC was to establish good working relationships with non-project staff, particularly DESC. This was at a time when Slack had very poor support for multiple workspaces and guest channel access. Moreover the LSSTC workspace is now well established for this purpose and ops leaders will remain reachable on it.
-\item  ``It's fine, we have private channels'': The proliferation of private channels have been a bit of a nightmare. We're always wondering who should or should not have access to them, forget to add new people, forget to off-board departing people, are unclear what channels  should or should not be private, etc. It also has led to reduced transparency within the project --- a number of channels that were open in the old slack space were made private when we moved to the LSSTC slack.
-\item  ``Too hard to determine out who is staff'': It's true that the proliferation of in-kind, grad students and other participants have muddied the waters. However this is a problem we still have in the current set-up -  it's just less obvious. The most clear heuristics include “are we paying (corollary: can we “fire”) someone who has violated project rules; are they on the builder's accrual list; do they have summit access; etc.
+\item ``We are at risk of abandoning the community'': The motivation behind LSSTC was to establish good working relationships with non-observatory staff, particularly DESC. This was at a time when Slack had very poor support for multiple workspaces and guest channel access. Moreover the LSSTC workspace is now well established for this purpose and ops leaders will remain reachable on it.
+\item  ``It's fine, we have private channels'': The proliferation of private channels in slack can be a bit of a nightmare. It leads to staff always wondering who should or should not have access to them, and are liable to forget to add new people, forget to off-board departing people, be unclear what channels  should or should not be private, etc. It also leads to reduced transparency within the project --- a number of channels that were open in the original Rubin slack space were made private when we moved to the LSSTC slack.
+\item  ``Too hard to determine who is staff'': It's true that the proliferation of in-kind, grad students and other participants have muddied the waters. However this is a problem we still have in the current set-up -  it's just less obvious. The most clear heuristics include “are we paying (corollary: can we “fire”) someone who has violated project rules; are they on the builder's accrual list; do they have summit access; etc.
 \item  ``We already say we don't do community user support on Slack'': This is true, we do say it, but we should recognize that it's emotionally hard work when someone is asking a question on Slack to determine whether they are staff or no, and if not to tell them to go elsewhere. Sometimes we just answer without checking, which muddies our stance.
 \item  ``We're too busy for this kind of change'': True, but this will only get worse. There is also a plan being prepared to provide more consistent naming for certain types of channels (support, status, etc.) and update default status semantics,  so this would be a good time to implement that.
 \end{itemize}
 
 
-Much as we dislike having ANOTHER Slack space resurrecting the old LSST Slack space adding only the team members with image access to it and using it for all the the nighttime summit channels would be a clean solution.
-Whether we make private channels or switch to a private space --- this needs to be done preferably before July 2024.
-We need to start a concrete plan for this.
+Much as we dislike having ANOTHER Slack space, resurrecting the old LSST Slack space and adding only the team members with image access to it, and then using it for all the the nighttime summit channels has been found to be a clean solution.
 
-\subsubsection{Proposed policy}
+\subsubsection{Approach}
 See also \secref{sec:genpol}.
-Resurrect lsst.slack.com Slack org for restricted use of the Rubin team, at least during commissioning.
+Resurrect lsst.slack.com Slack workspace as Rubin Observatory Slack, for restricted use of the Rubin team, at least during commissioning.
 
-Reuse of lsst.slack.com as some advantages:
+Reuse of lsst.slack.com has had some advantages:
 
 \begin{itemize}
-\item  This is already set up grandfathered as free so we don't risk applying and being turned down for another free workspace
-\item  Can deliberately blur construction / commissioning / ops lines since it is free
-\item  Rubin would be in total control of configuration, access and any paid features
-\item  Workspace is already configured for our use which would speed up any transition
+\item  It was already set up grandfathered as free so we don't risk applying and being turned down for another free workspace
+\item  We can deliberately blur construction / commissioning / ops lines since it is free
+\item  Rubin is in total control of configuration, access and any paid features
+\item  Workspace was already configured for our use which would speed up any transition
 
 \end{itemize}
-We could revisit after commissioning.
+We can revisit this approach after commissioning.
 
 Even though this is a private space it is not encrypted and not all project members have access to commissioning data.
 Some care, such as not posting full images and certainly not frequently doing so, should be taken.


### PR DESCRIPTION
As issued in https://rubinobs.atlassian.net/browse/PREOPS-6549

This PR brings DMTN-286 up to date and into full (word by word) alignment with the Staff Access Form at https://ls.st/staff-access-form, as revised and advertized to staff in Rubin Slack #all-users on December 12 2024.
